### PR TITLE
swapForExactOutputAmount

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,21 @@ yarn
 yarn compile
 ```
 
-## more coming soon :wink:
+# MadSBT
+Hybrid between ERC721/ERC1155; collections, dynamic metadata, and points system
+
+Flow of operations
+1. anyone with a Lens profile can call `#createCollection` which sets the storage for an incremental `collectionId`, and creates an index for IDA (ex: supertoken will be USDCx)
+2. only the creator and permissioned addresses can call `#mint`; permissioned address can be contracts with different business logic (paid mint, free, subscription, etc)
+3. as the user interacts with other MadFi contract, they earn points; permissioned contracts can call `#handleRewardsUpdate` which takes an enum and updates the IDA units by a fixed amount (ex: 50, 100, etc)
+4. anyone can all `#distributeRewards` with a `collectionId` and `totalAmount` of the set `rewardsToken` for the contract to take the tokens and distribute amongst holders of the nft at `collectionId`
+5. cross-chain payloads can be received (via wormhole) to mint / burn
+
+# SubscriptionHandler
+Implements Superfluid CFAv1 via abstract contract `FlowReceiver`. Flow create operations expect `userData` to contain the intended receiver. Manages the creation of streams to intended creators by taking a protocol fee on create, minting the associated MadSBT for the creator's collection, and burning when stream is closed.
+
+Flow of operations
+1. `FlowReceiver.sol` handles all superfluid callbacks
+1. anyone can open a stream to this contract with `userData` containing the intended receiver, collectionId, etc
+2. we take a protocol fee by opening a stream (ex: 90% of the flowRate) to the intended receiver, or updating the existing stream
+3. `SubscriptionHandler.sol` handles business logic by minting or burning the MadSBT for the associated collection

--- a/contracts/interfaces/ISocialClubReferrals.sol
+++ b/contracts/interfaces/ISocialClubReferrals.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+interface ISocialClubReferrals {
+    function processBadgeCreate(
+        uint256 collectionId,
+        address referrer,
+        address creator,
+        uint256 creatorProfileId
+    ) external;
+}

--- a/contracts/interfaces/ISubscriptionHandler.sol
+++ b/contracts/interfaces/ISubscriptionHandler.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+/**
+ * @notice ISubscriptionHandler interface
+ * @dev the bare minimum needed for MadSBT
+ */
+interface ISubscriptionHandler {
+  function hasActiveSubscription(address subscriber, address creator) external view returns (bool);
+}

--- a/contracts/interfaces/IUniswap.sol
+++ b/contracts/interfaces/IUniswap.sol
@@ -16,8 +16,53 @@ interface ISwapRouter {
         uint160 sqrtPriceLimitX96;
     }
 
+    struct ExactOutputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+        uint160 sqrtPriceLimitX96;
+    }
+
     /// @notice Swaps `amountIn` of one token for as much as possible of another token
     /// @param params The parameters necessary for the swap, encoded as `ExactInputSingleParams` in calldata
     /// @return amountOut The amount of the received token
     function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+
+    /// @notice Swaps up to `amountInMaximum` of one token for the exact `amountOut` of another token
+    /// @param params The parameters necessary for the swap, encoded as `ExactOutputSingleParams` in calldata
+    /// @return amountIn The necessary amount of the `tokenIn` token needed for the swap
+    function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+
+    /// @notice Returns the amount in required to receive the given exact output amount but for a swap of a single pool
+    /// @param tokenIn The token being swapped in
+    /// @param tokenOut The token being swapped out
+    /// @param fee The fee of the token pool to consider for the pair
+    /// @param amountOut The desired output amount
+    /// @param sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+    /// @return amountIn The amount required as the input for the swap in order to receive amountOut
+    function quoteExactOutputSingle(
+        address tokenIn,
+        address tokenOut,
+        uint24 fee,
+        uint256 amountOut,
+        uint160 sqrtPriceLimitX96
+    ) external returns (uint256 amountIn);
+
+    /// @notice Returns the amount out received for a given exact input but for a swap of a single pool
+    /// @param tokenIn The token being swapped in
+    /// @param tokenOut The token being swapped out
+    /// @param fee The fee of the token pool to consider for the pair
+    /// @param amountIn The desired input amount
+    /// @param sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+    function quoteExactInputSingle(
+        address tokenIn,
+        address tokenOut,
+        uint24 fee,
+        uint256 amountIn,
+        uint160 sqrtPriceLimitX96
+    ) external returns (uint256 amountOut);
 }

--- a/contracts/interfaces/IUniswap.sol
+++ b/contracts/interfaces/IUniswap.sol
@@ -36,7 +36,9 @@ interface ISwapRouter {
     /// @param params The parameters necessary for the swap, encoded as `ExactOutputSingleParams` in calldata
     /// @return amountIn The necessary amount of the `tokenIn` token needed for the swap
     function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+}
 
+interface IQuoter {
     /// @notice Returns the amount in required to receive the given exact output amount but for a swap of a single pool
     /// @param tokenIn The token being swapped in
     /// @param tokenOut The token being swapped out

--- a/contracts/libraries/RevShare.sol
+++ b/contracts/libraries/RevShare.sol
@@ -2,16 +2,16 @@
 
 /*
 
-__/\\\\____________/\\\\_____/\\\\\\\\\_____/\\\\\\\\\\\\_____/\\\\\\\\\\\\\\\__/\\\\\\\\\\\_        
- _\/\\\\\\________/\\\\\\___/\\\\\\\\\\\\\__\/\\\////////\\\__\/\\\///////////__\/////\\\///__       
-  _\/\\\//\\\____/\\\//\\\__/\\\/////////\\\_\/\\\______\//\\\_\/\\\_________________\/\\\_____      
-   _\/\\\\///\\\/\\\/_\/\\\_\/\\\_______\/\\\_\/\\\_______\/\\\_\/\\\\\\\\\\\_________\/\\\_____     
-    _\/\\\__\///\\\/___\/\\\_\/\\\\\\\\\\\\\\\_\/\\\_______\/\\\_\/\\\///////__________\/\\\_____    
-     _\/\\\____\///_____\/\\\_\/\\\/////////\\\_\/\\\_______\/\\\_\/\\\_________________\/\\\_____   
-      _\/\\\_____________\/\\\_\/\\\_______\/\\\_\/\\\_______/\\\__\/\\\_________________\/\\\_____  
-       _\/\\\_____________\/\\\_\/\\\_______\/\\\_\/\\\\\\\\\\\\/___\/\\\______________/\\\\\\\\\\\_ 
+__/\\\\____________/\\\\_____/\\\\\\\\\_____/\\\\\\\\\\\\_____/\\\\\\\\\\\\\\\__/\\\\\\\\\\\_
+ _\/\\\\\\________/\\\\\\___/\\\\\\\\\\\\\__\/\\\////////\\\__\/\\\///////////__\/////\\\///__
+  _\/\\\//\\\____/\\\//\\\__/\\\/////////\\\_\/\\\______\//\\\_\/\\\_________________\/\\\_____
+   _\/\\\\///\\\/\\\/_\/\\\_\/\\\_______\/\\\_\/\\\_______\/\\\_\/\\\\\\\\\\\_________\/\\\_____
+    _\/\\\__\///\\\/___\/\\\_\/\\\\\\\\\\\\\\\_\/\\\_______\/\\\_\/\\\///////__________\/\\\_____
+     _\/\\\____\///_____\/\\\_\/\\\/////////\\\_\/\\\_______\/\\\_\/\\\_________________\/\\\_____
+      _\/\\\_____________\/\\\_\/\\\_______\/\\\_\/\\\_______/\\\__\/\\\_________________\/\\\_____
+       _\/\\\_____________\/\\\_\/\\\_______\/\\\_\/\\\\\\\\\\\\/___\/\\\______________/\\\\\\\\\\\_
         _\///______________\///__\///________\///__\////////////_____\///______________\///////////__
-                                        
+
 */
 
 pragma solidity ^0.8.10;
@@ -22,6 +22,8 @@ import "../interfaces/IUniswap.sol";
 import "../interfaces/ISuperToken.sol";
 
 library RevShare {
+    error InsufficientAmountInForQuote();
+
     /**
      * @dev Distribute rewards to a collection
      * @param madSBT The MadSBT contract
@@ -45,24 +47,7 @@ library RevShare {
         // check if token is underlying
         if (token != underlying) {
             // swap token to underlying
-            ISwapRouter uniswapV3Router = ISwapRouter(swapRouter);
-
-            IERC20(token).approve(address(uniswapV3Router), revShareAmount);
-
-            ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
-                tokenIn: token,
-                tokenOut: underlying,
-                fee: fee, // 500, 3000, 10000
-                recipient: address(this),
-                deadline: block.timestamp + 15,
-                amountIn: revShareAmount,
-                amountOutMinimum: 0,
-                sqrtPriceLimitX96: 0
-            });
-
-            uniswapV3Router.exactInputSingle(params);
-
-            revShareAmount = IERC20(underlying).balanceOf(address(this));
+            revShareAmount = swapExactInputAmount(token, underlying, swapRouter, revShareAmount, fee);
         }
 
         // wrap as super usdc
@@ -72,5 +57,89 @@ library RevShare {
         // instant distribution
         IERC20(rewardsToken).approve(address(madSBT), revShareAmount);
         madSBT.distributeRewards(collectionId, revShareAmount);
+    }
+
+    /**
+     * @dev Swap one currency for another, for exactly `outputAmount` of `tokenOut`
+     * @param tokenIn The token to swap from
+     * @param tokenOut The token to swap to
+     * @param swapRouter The swap router to use
+     * @param amountInMaximum The maximum input amount of `tokenIn`
+     * @param outputAmount The exact output amount desired of `tokenOut`
+     * @param fee The fee for the pool to swap through
+     * @param doSanityCheck Validate whether the `amountInMaximum` covers the quoted amount
+     * @return deltaAmountIn The delta between `amountInMaximum` and what was actually needed - to be refunded
+     */
+    function swapForExactOutputAmount(
+        address tokenIn,
+        address tokenOut,
+        address swapRouter,
+        uint256 amountInMaximum,
+        uint256 outputAmount,
+        uint24 fee,
+        bool doSanityCheck
+    ) public returns (uint256 deltaAmountIn) {
+        ISwapRouter uniswapV3Router = ISwapRouter(swapRouter);
+
+        if (doSanityCheck) {
+            uint256 quotedAmountIn = uniswapV3Router.quoteExactOutputSingle(tokenIn, tokenOut, fee, outputAmount, 0);
+            if (amountInMaximum < quotedAmountIn) revert InsufficientAmountInForQuote();
+        }
+
+        IERC20(tokenIn).approve(address(uniswapV3Router), amountInMaximum);
+
+        ISwapRouter.ExactOutputSingleParams memory params = ISwapRouter.ExactOutputSingleParams({
+            tokenIn: tokenIn,
+            tokenOut: tokenOut,
+            fee: fee, // 500, 3000, 10000
+            recipient: address(this),
+            deadline: block.timestamp + 15,
+            amountOut: outputAmount,
+            amountInMaximum: amountInMaximum,
+            sqrtPriceLimitX96: 0
+        });
+
+        uint256 amountIn = uniswapV3Router.exactOutputSingle(params);
+
+        // `amountInMaximum` may not have all been spent
+        if (amountIn < amountInMaximum) {
+            // reduce the approved balance, and caller should refund `deltaAmountIn`
+            IERC20(tokenIn).approve(address(uniswapV3Router), 0);
+            deltaAmountIn = amountInMaximum - amountIn;
+        }
+    }
+
+    /**
+     * @dev Swap one currency for another, exactly `amountIn` of `tokenIn`
+     * @param tokenIn The token to swap from
+     * @param tokenOut The token to swap to
+     * @param swapRouter The swap router to use
+     * @param amountIn The input amount of `tokenIn`
+     * @param fee The fee for the pool to swap through
+     * @return amountOut The amount of the received token
+     */
+    function swapExactInputAmount(
+        address tokenIn,
+        address tokenOut,
+        address swapRouter,
+        uint256 amountIn,
+        uint24 fee
+    ) public returns (uint256 amountOut) {
+        ISwapRouter uniswapV3Router = ISwapRouter(swapRouter);
+
+        IERC20(tokenIn).approve(address(uniswapV3Router), amountIn);
+
+        ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
+            tokenIn: tokenIn,
+            tokenOut: tokenOut,
+            fee: fee, // 500, 3000, 10000
+            recipient: address(this),
+            deadline: block.timestamp + 15,
+            amountIn: amountIn,
+            amountOutMinimum: 0,
+            sqrtPriceLimitX96: 0
+        });
+
+        amountOut = uniswapV3Router.exactInputSingle(params);
     }
 }

--- a/contracts/libraries/RevShare.sol
+++ b/contracts/libraries/RevShare.sol
@@ -16,9 +16,9 @@ __/\\\\____________/\\\\_____/\\\\\\\\\_____/\\\\\\\\\\\\_____/\\\\\\\\\\\\\\\__
 
 pragma solidity ^0.8.10;
 
+import {ISwapRouter} from "../interfaces/IUniswap.sol";
 import "../interfaces/IERC20.sol";
 import "../interfaces/IMadSBT.sol";
-import "../interfaces/IUniswap.sol";
 import "../interfaces/ISuperToken.sol";
 
 library RevShare {
@@ -67,7 +67,6 @@ library RevShare {
      * @param amountInMaximum The maximum input amount of `tokenIn`
      * @param outputAmount The exact output amount desired of `tokenOut`
      * @param fee The fee for the pool to swap through
-     * @param doSanityCheck Validate whether the `amountInMaximum` covers the quoted amount
      * @return deltaAmountIn The delta between `amountInMaximum` and what was actually needed - to be refunded
      */
     function swapForExactOutputAmount(
@@ -76,15 +75,9 @@ library RevShare {
         address swapRouter,
         uint256 amountInMaximum,
         uint256 outputAmount,
-        uint24 fee,
-        bool doSanityCheck
+        uint24 fee
     ) public returns (uint256 deltaAmountIn) {
         ISwapRouter uniswapV3Router = ISwapRouter(swapRouter);
-
-        if (doSanityCheck) {
-            uint256 quotedAmountIn = uniswapV3Router.quoteExactOutputSingle(tokenIn, tokenOut, fee, outputAmount, 0);
-            if (amountInMaximum < quotedAmountIn) revert InsufficientAmountInForQuote();
-        }
 
         IERC20(tokenIn).approve(address(uniswapV3Router), amountInMaximum);
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type import('hardhat/config').HardhatUserConfig
+ */
+module.exports = {
+  solidity: "0.8.20",
+};


### PR DESCRIPTION
## CHANGES
to support `ZoraMintAction` we need users to swap whatever they want (Lens whitelisted currency) into the native token (MATIC) in order to relay to the zora creator on Zora network as ETH

- new  function `swapForExactOutputAmount` in `RevShare.sol`
- new interface in `quoteExactOutputSingle` in `IUniswap.sol` to help with the quotes

## TODO
- [x] test
- [x] redeploy to mumbai